### PR TITLE
skips variable were not defined

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -208,6 +208,7 @@ class Suite(object):
         :return:
         """
         fails = ""
+        skips = ""
 
         if len(self.failed()):
             faillist = list()


### PR DESCRIPTION
If there are no skipped tests the skipps varaible are never
initialized. It causes exception.