### PR TITLE
Fixed undefined time attribute.

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -446,7 +446,7 @@ class Junit(object):
                     newcase = Case()
                     newcase.name = testcase.attrib["name"]
                     newcase.testclass = testclass
-                    newcase.duration = float(testcase.attrib["time"])
+                    newcase.duration = float(testcase.attrib.get("time", '0'))
                     testclass.cases.append(newcase)
 
                     # does this test case have any children?


### PR DESCRIPTION
Added a default value.

newcase.duration = float(testcase.attrib.get("time", '0'))