### PR TITLE
Changed junit2html shebang to use /usr/bin/env.

### DIFF
--- a/junit2html
+++ b/junit2html
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from junit2htmlreport import runner
 runner.start()


### PR DESCRIPTION
Hardcoded #!/usr/bin/python shebang prevents using the package properly
in a virtualenv or if python executable is in another path. Using
/usr/bin/env is not limited in this way.