### PR TITLE
Testclassname bug fix 

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -443,6 +443,7 @@ class Junit(object):
 
                         cursuite[testclass.name] = testclass
 
+                    testclass = cursuite[testcase.attrib["classname"]]
                     newcase = Case()
                     newcase.name = testcase.attrib["name"]
                     newcase.testclass = testclass


### PR DESCRIPTION
https://github.com/inorton/junit2html/issues/16

There is an error in the conversion Testclassname in parser.py.
If you are adding a new testcase testclassname already registered, your code can not put testclassname correctly. 