### PR TITLE
Fix python 3 support

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -401,7 +401,7 @@ class Junit(object):
         :return:
         """
         thisdir = os.path.dirname(os.path.abspath(__file__))
-        with open(os.path.join(thisdir, self.css), "rb") as cssfile:
+        with open(os.path.join(thisdir, self.css), "r") as cssfile:
             return cssfile.read()
 
     def process(self):

--- a/junit2htmlreport/runner.py
+++ b/junit2htmlreport/runner.py
@@ -29,7 +29,12 @@ def run(args):
     report = parser.Junit(args[0])
     html = report.html()
 
-    with open(outfilename, "wb") as outfile:
+    # In python3 this is going to be a str
+    bytes_mode = ""
+    if isinstance(html, bytes):
+        bytes_mode = "b"
+
+    with open(outfilename, "w" + bytes_mode) as outfile:
         outfile.write(html)
 
 

--- a/junit2htmlreport/tag.py
+++ b/junit2htmlreport/tag.py
@@ -13,7 +13,13 @@ def text(content):
     """
     string = ""
     if content is not None:
-        string = content.encode("utf-8")
+        # Convert unicode str to bytes in Python 2
+        # Python 3 is using unicode natively
+        string = content
+        try:
+            if isinstance(content, unicode):
+                string = content.encode("utf-8")
+        except:
+            pass
         #string = content.encode('ascii', 'xmlcharrefreplace')
     return cgi.escape(string)
-


### PR DESCRIPTION
* Only convert to bytes if this is python2.
* Only write output in binary mode if we have bytes.

This patch tries to fix #18.