### PR TITLE
Fixed incompatibility with 3.8 (can't import cgi.escape)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.8"

--- a/junit2htmlreport/tag.py
+++ b/junit2htmlreport/tag.py
@@ -2,7 +2,11 @@
 Crude generation of HTML
 """
 
-import cgi
+import sys
+if sys.version_info >= (3, 0):
+    from html import escape
+else:
+    from cgi import escape
 
 
 def text(content):
@@ -14,4 +18,4 @@ def text(content):
     string = ""
     if content is not None:
         string = content
-    return cgi.escape(string)
+    return escape(string)


### PR DESCRIPTION
Hey, I've noticed upon bumping the Python version to 3.8 in our CI, that the package will fail for this version. It uses `cgi.escape` which was deprecated in 3.7 and removed in 3.8, so I made a quick fix for compatibility.

Leaving it here just in case you decide you need this addition, or someone else stumbles at the same problem.
I'll be happy to hear any comments.

Thanks!