### PR TITLE
Provide entry point compatible with Windows too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url="https://gitlab.com/inorton/junit2html",
     packages=["junit2htmlreport"],
     package_data={"junit2htmlreport": files},
-    scripts=["junit2html"],
+    entry_points={'console_scripts': ['junit2html=junit2htmlreport.runner:start']},
     platforms=["any"],
     license="License :: OSI Approved :: MIT License",
     long_description="Genearate a single file HTML report from a Junit XML file"


### PR DESCRIPTION
Exposing the shell script https://github.com/inorton/junit2html/blob/0fb215848dd63a0e9bfec0f677e048bb5afa2f1a/junit2html does not give an executable entry point on Windows.

When using setuptools' [`entry_points`](https://github.com/sirhcel/junit2html/blob/bbf776ed391af420092850298158a8719bea16b7/setup.py#L15), `junit2html.exe` and a companion script will be generated on Windows to make `junit2html` avaliable on the command line. On *nix systems just a wrapper script will be generated and so this mechanism serves both platforms.

Keeping https://github.com/inorton/junit2html/blob/0fb215848dd63a0e9bfec0f677e048bb5afa2f1a/junit2html in the repository allows to run the program during development without installing the package.