### PR TITLE
Add a missing closing tag

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -535,7 +535,7 @@ class Suite(AnchorBase, ToJunitXmlBase):
 
         return """
         <div class="testsuite">
-            <h2>Test Suite: {name}</h2><a name="{anchor}">
+            <h2>Test Suite: {name}</h2><a name="{anchor}"/>
             {package}
             {properties}
             <table>


### PR DESCRIPTION
At the beginning of the Testsuite an "a" tag is opened but never
closed. Therefore, close the tag.