### PR TITLE
set summary-matrix output to use utf-8 encoding

### DIFF
--- a/junit2htmlreport/runner.py
+++ b/junit2htmlreport/runner.py
@@ -56,7 +56,7 @@ def run(args):
         util = matrix.TextReportMatrix()
         for filename in inputs:
             util.add_report(filename)
-        print(util.summary())
+        print(util.summary().encoding("utf-8"))
     elif opts.html_matrix:
         util = matrix.HtmlReportMatrix(os.path.dirname(opts.html_matrix))
         for filename in inputs:


### PR DESCRIPTION
have matrix files output by default to utf-8 encoding.  ascii/plain text is too limited and this change prevents errors like this
https://stackoverflow.com/questions/13493477/unicodeencodeerror-ascii-codec-cant-encode-characters

this also matches the encoding already used by html