### PR TITLE
Current condition fails when "time" is set to empty string

### DIFF
--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -359,7 +359,7 @@ class Junit(object):
             cursuite.name = suitename
             if "package" in suite.attrib:
                 cursuite.package = suite.attrib["package"]
-            cursuite.duration = float(suite.attrib.get("time", '0').replace(',', ''))
+            cursuite.duration = float(suite.attrib.get("time", '0').replace(',', '') or '0')
 
             for element in suite:
                 if element.tag == "error":
@@ -398,7 +398,7 @@ class Junit(object):
                     newcase = Case()
                     newcase.name = testcase.attrib["name"]
                     newcase.testclass = testclass
-                    newcase.duration = float(testcase.attrib.get("time", '0').replace(',',''))
+                    newcase.duration = float(testcase.attrib.get("time", '0').replace(',','') or '0')
                     testclass.cases.append(newcase)
 
                     # does this test case have any children?


### PR DESCRIPTION
Hi,

I tried to use your script with junit files produced by [trivy](https://github.com/aquasecurity/trivy)
It generates files like this:
```
...
<testsuite tests="1" failures="2" time="" name= ...
...
```

Sadly when `time` is set, but to empty string `get` will return this empty string. Empty string can't be converted to `float`:
```
Traceback (most recent call last):
  File "/usr/local/bin/junit2html", line 8, in <module>
    sys.exit(start())
  File "/usr/local/lib/python3.6/site-packages/junit2htmlreport/runner.py", line 101, in start
    run(sys.argv[1:])
  File "/usr/local/lib/python3.6/site-packages/junit2htmlreport/runner.py", line 90, in run
    report = parser.Junit(args[0])
  File "/usr/local/lib/python3.6/site-packages/junit2htmlreport/parser.py", line 316, in __init__
    self.process()
  File "/usr/local/lib/python3.6/site-packages/junit2htmlreport/parser.py", line 362, in process
    cursuite.duration = float(suite.attrib.get("time", '0').replace(',', ''))
ValueError: could not convert string to float:
```

Patch below handles this situation and make script to work.

Best regards,
Tomasz.