### PR TITLE
Add colors to report and other "dev experience" changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ MANIFEST
 *.xml.html
 *.egg-info
 *.code-workspace
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 *.xml
 *.xml.html
 *.egg-info
+*.code-workspace

--- a/junit2htmlreport/case_result.py
+++ b/junit2htmlreport/case_result.py
@@ -10,3 +10,6 @@ class CaseResult(str, Enum):
     SKIPPED = "skipped"  # the test was skipped
     PASSED = "passed"  # the test completed successfully
     ABSENT = "absent"  # the test was known but not run/failed/skipped
+
+    def __str__(self) -> str:
+        return self.value

--- a/junit2htmlreport/case_result.py
+++ b/junit2htmlreport/case_result.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class CaseResult(str, Enum):
+    UNTESTED = "untested"
+    PARTIAL_PASS = "partial pass"
+    PARTIAL_FAIL = "partial failure"
+    TOTAL_FAIL = "total failure"
+    FAILED = "failed"  # the test failed
+    SKIPPED = "skipped"  # the test was skipped
+    PASSED = "passed"  # the test completed successfully
+    ABSENT = "absent"  # the test was known but not run/failed/skipped

--- a/junit2htmlreport/common.py
+++ b/junit2htmlreport/common.py
@@ -17,7 +17,7 @@ class ReportContainer(object):
     def __init__(self):
         self.reports = {}
 
-    def add_report(self, filename: str) -> Any:
+    def add_report(self, filename: str) -> None:
         raise NotImplementedError()
 
     def failures(self):

--- a/junit2htmlreport/common.py
+++ b/junit2htmlreport/common.py
@@ -3,15 +3,21 @@ Common code between JUnit2HTML matrix and merge classes
 """
 from __future__ import print_function
 
+from typing import Any
+
+from junit2htmlreport.parser import Case, Junit
+
 
 class ReportContainer(object):
     """
     Hold one or more reports
     """
+    reports: dict[str, Junit]
+
     def __init__(self):
         self.reports = {}
 
-    def add_report(self, file):
+    def add_report(self, filename: str) -> Any:
         raise NotImplementedError()
 
     def failures(self):
@@ -19,7 +25,7 @@ class ReportContainer(object):
         Return all the failed test cases
         :return:
         """
-        found = []
+        found: list[Case] = []
         for report in self.reports:
             for suite in self.reports[report].suites:
                 found.extend(suite.failed())
@@ -31,7 +37,7 @@ class ReportContainer(object):
         Return all the skipped test cases
         :return:
         """
-        found = []
+        found: list[Case] = []
         for report in self.reports:
             for suite in self.reports[report].suites:
                 found.extend(suite.skipped())

--- a/junit2htmlreport/common.py
+++ b/junit2htmlreport/common.py
@@ -3,9 +3,7 @@ Common code between JUnit2HTML matrix and merge classes
 """
 from __future__ import print_function
 
-from typing import Any
-
-from junit2htmlreport.parser import Case, Junit
+from .parser import Case, Junit
 
 
 class ReportContainer(object):

--- a/junit2htmlreport/matrix.py
+++ b/junit2htmlreport/matrix.py
@@ -4,22 +4,24 @@ Handle multiple parsed junit reports
 from __future__ import unicode_literals
 
 import os
-from enum import Enum
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from .parser import Case, Class
 
 from . import parser
+from .case_result import CaseResult
 from .common import ReportContainer
-from .parser import Case, CaseResult, Class
-from .render import HTMLMatrix, HTMLReport
+from .render import HTMLMatrix
 
 
 class ReportMatrix(ReportContainer):
     """
     Load and handle several report files
     """
-    cases: dict[str, dict[str, dict[str, Case]]]
-    classes: dict[str, dict[str, Class]]
-    casenames: dict[str, list[str]]
+    cases: "dict[str, dict[str, dict[str, Case]]]"
+    classes: "dict[str, dict[str, Class]]"
+    casenames: "dict[str, list[str]]"
     result_stats: dict[CaseResult, int]
     case_results: dict[str, dict[str, list[CaseResult]]]
 
@@ -31,7 +33,7 @@ class ReportMatrix(ReportContainer):
         self.result_stats = {}
         self.case_results = {}
 
-    def add_case_result(self, case: Case):
+    def add_case_result(self, case: "Case"):
         if case.testclass is None or case.testclass.name is None:
             testclass = ""
         else:
@@ -228,7 +230,7 @@ class TextReportMatrix(ReportMatrix):
 
                 # print each test and its result for each axis
                 case_data = ""
-                testcase: Case|None = None
+                testcase: "Case|None" = None
                 for axis in self.report_order():
                     if axis not in self.cases[classname][casename]:
                         case_data += "  "

--- a/junit2htmlreport/matrix.py
+++ b/junit2htmlreport/matrix.py
@@ -2,22 +2,26 @@
 Handle multiple parsed junit reports
 """
 from __future__ import unicode_literals
+
 import os
+from enum import Enum
+from typing import Any, Literal
+
 from . import parser
 from .common import ReportContainer
-from .parser import SKIPPED, FAILED, PASSED, ABSENT
+from .parser import Case, CaseResult, Class
 from .render import HTMLMatrix, HTMLReport
-
-UNTESTED = "untested"
-PARTIAL_PASS = "partial pass"
-PARTIAL_FAIL = "partial failure"
-TOTAL_FAIL = "total failure"
 
 
 class ReportMatrix(ReportContainer):
     """
     Load and handle several report files
     """
+    cases: dict[str, dict[str, dict[str, Case]]]
+    classes: dict[str, dict[str, Class]]
+    casenames: dict[str, list[str]]
+    result_stats: dict[CaseResult, int]
+    case_results: dict[str, dict[str, list[CaseResult]]]
 
     def __init__(self):
         super(ReportMatrix, self).__init__()
@@ -27,9 +31,12 @@ class ReportMatrix(ReportContainer):
         self.result_stats = {}
         self.case_results = {}
 
-    def add_case_result(self, case):
-        testclass = case.testclass.name
-        casename = case.name
+    def add_case_result(self, case: Case):
+        if case.testclass is None or case.testclass.name is None:
+            testclass = ""
+        else:
+            testclass = case.testclass.name
+        casename = "" if case.name is None else case.name
         if testclass not in self.case_results:
             self.case_results[testclass] = {}
         if casename not in self.case_results[testclass]:
@@ -39,25 +46,25 @@ class ReportMatrix(ReportContainer):
     def report_order(self):
         return sorted(self.reports.keys())
 
-    def short_outcome(self, outcome):
-        if outcome == PASSED:
+    def short_outcome(self, outcome: CaseResult) -> Literal['ok', '/', 's', 'f', 'F', '%', 'X', 'U', '?']:
+        if outcome == CaseResult.PASSED:
             return "/"
-        elif outcome == SKIPPED:
+        elif outcome == CaseResult.SKIPPED:
             return "s"
-        elif outcome == FAILED:
+        elif outcome == CaseResult.FAILED:
             return "f"
-        elif outcome == TOTAL_FAIL:
+        elif outcome == CaseResult.TOTAL_FAIL:
             return "F"
-        elif outcome == PARTIAL_PASS:
+        elif outcome == CaseResult.PARTIAL_PASS:
             return "%"
-        elif outcome == PARTIAL_FAIL:
+        elif outcome == CaseResult.PARTIAL_FAIL:
             return "X"
-        elif outcome == UNTESTED:
+        elif outcome == CaseResult.UNTESTED:
             return "U"
 
         return "?"
 
-    def add_report(self, filename):
+    def add_report(self, filename: str):
         """
         Load a report into the matrix
         :param filename:
@@ -72,11 +79,11 @@ class ReportMatrix(ReportContainer):
                 if testclass not in self.classes:
                     self.classes[testclass] = {}
                 if testclass not in self.casenames:
-                    self.casenames[testclass] = list()
+                    self.casenames[testclass] = []
                 self.classes[testclass][filename] = suite.classes[testclass]
 
                 for testcase in self.classes[testclass][filename].cases:
-                    name = testcase.name.strip()
+                    name = "" if testcase.name is None else testcase.name.strip()
                     if name not in self.casenames[testclass]:
                         self.casenames[testclass].append(name)
 
@@ -92,14 +99,14 @@ class ReportMatrix(ReportContainer):
                     self.result_stats[outcome] = 1 + self.result_stats.get(
                         outcome, 0)
 
-    def summary(self):
+    def summary(self) -> str:
         """
         Render a summary of the matrix
         :return:
         """
         raise NotImplementedError()
 
-    def combined_result_list(self, classname, casename):
+    def combined_result_list(self, classname: str, casename: str):
         """
         Combone the result of all instances of the given case
         :param classname:
@@ -113,22 +120,22 @@ class ReportMatrix(ReportContainer):
 
         return " ", ""
 
-    def combined_result(self, results):
+    def combined_result(self, results: list[CaseResult]):
         """
         Given a list of results, produce a "combined" overall result
         :param results:
         :return:
         """
         if results:
-            if PASSED in results:
-                if FAILED in results:
-                    return self.short_outcome(PARTIAL_FAIL), PARTIAL_FAIL.title()
-                return self.short_outcome(PASSED), PASSED.title()
+            if CaseResult.PASSED in results:
+                if CaseResult.FAILED in results:
+                    return self.short_outcome(CaseResult.PARTIAL_FAIL), CaseResult.PARTIAL_FAIL.title()
+                return self.short_outcome(CaseResult.PASSED), CaseResult.PASSED.title()
 
-            if FAILED in results:
-                return self.short_outcome(FAILED), FAILED.title()
-            if SKIPPED in results:
-                return self.short_outcome(UNTESTED), UNTESTED.title()
+            if CaseResult.FAILED in results:
+                return self.short_outcome(CaseResult.FAILED), CaseResult.FAILED.title()
+            if CaseResult.SKIPPED in results:
+                return self.short_outcome(CaseResult.UNTESTED), CaseResult.UNTESTED.title()
         return " ", ""
 
 
@@ -137,11 +144,13 @@ class HtmlReportMatrix(ReportMatrix):
     Render a matrix report as html
     """
 
-    def __init__(self, outdir):
+    outdir: str
+
+    def __init__(self, outdir: str):
         super(HtmlReportMatrix, self).__init__()
         self.outdir = outdir
 
-    def add_report(self, filename):
+    def add_report(self, filename: str):
         """
         Load a report
         """
@@ -155,12 +164,12 @@ class HtmlReportMatrix(ReportMatrix):
                 os.path.join(self.outdir, basename) + ".html", "wb") as filehandle:
             filehandle.write(report.encode("utf-8"))
 
-    def short_outcome(self, outcome):
-        if outcome == PASSED:
+    def short_outcome(self, outcome: CaseResult) -> Literal['ok', '/', 's', 'f', 'F', '%', 'X', 'U', '?']:
+        if outcome == CaseResult.PASSED:
             return "ok"
         return super(HtmlReportMatrix, self).short_outcome(outcome)
 
-    def short_axis(self, axis):
+    def short_axis(self, axis: str):
         if axis.endswith(".xml"):
             return axis[:-4]
         return axis
@@ -219,6 +228,7 @@ class TextReportMatrix(ReportMatrix):
 
                 # print each test and its result for each axis
                 case_data = ""
+                testcase: Case|None = None
                 for axis in self.report_order():
                     if axis not in self.cases[classname][casename]:
                         case_data += "  "
@@ -231,8 +241,12 @@ class TextReportMatrix(ReportMatrix):
                         else:
                             case_data += "/ "
 
+                if testcase is None or testcase.name is None:
+                    testcase_name = ""
+                else:
+                    testcase_name = testcase.name
                 combined, combined_name = self.combined_result(
-                    self.case_results[classname][testcase.name])
+                    self.case_results[classname][testcase_name])
 
                 output += case_data
                 output += " {} {}\n".format(combined, combined_name)

--- a/junit2htmlreport/merge.py
+++ b/junit2htmlreport/merge.py
@@ -2,15 +2,17 @@
 Classes for merging several reports into one
 """
 from __future__ import unicode_literals
+
 import os
+import xml.etree.ElementTree as ET
 from io import BytesIO
+
 from junit2htmlreport import parser
 from junit2htmlreport.common import ReportContainer
 from junit2htmlreport.textutils import unicode_str
-import xml.etree.ElementTree as ET
 
 
-def has_xml_header(filepath):
+def has_xml_header(filepath: str):
     """
     Return True if the first line of the file is <?xml
     :param filepath:
@@ -23,11 +25,13 @@ class Merger(ReportContainer, parser.ToJunitXmlBase):
     """
     Utility class to create a merged junix xml report
     """
+    suites: list[parser.Suite]
+
     def __init__(self):
         super(Merger, self).__init__()
         self.suites = []
 
-    def add_report(self, filename):
+    def add_report(self, filename: str):
         """
         Load a test report or folder
         :param filename:
@@ -40,8 +44,8 @@ class Merger(ReportContainer, parser.ToJunitXmlBase):
                 self.suites.append(suite)
         elif os.path.isdir(filename):
             # try importing all files in this folder
-            for root, dirs, files in os.walk(filename):
-                for filename in files:
+            for root, _, files in os.walk(filename):
+                for _ in files:
                     filepath = os.path.join(root, filename)
                     if has_xml_header(filepath):
                         try:
@@ -49,7 +53,7 @@ class Merger(ReportContainer, parser.ToJunitXmlBase):
                         except (parser.ParserError, ET.ParseError):
                             pass
 
-    def add_suite(self, suite):
+    def add_suite(self, suite: parser.Suite):
         """
         Add a suite to the merge
         :param suite:

--- a/junit2htmlreport/merge.py
+++ b/junit2htmlreport/merge.py
@@ -7,9 +7,9 @@ import os
 import xml.etree.ElementTree as ET
 from io import BytesIO
 
-from junit2htmlreport import parser
-from junit2htmlreport.common import ReportContainer
-from junit2htmlreport.textutils import unicode_str
+from . import parser
+from .common import ReportContainer
+from .textutils import unicode_str
 
 
 def has_xml_header(filepath: str):

--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -10,6 +10,7 @@ import collections
 import os
 import uuid
 import xml.etree.ElementTree as ET
+from enum import Enum
 from typing import Any, OrderedDict
 
 from .render import HTMLReport
@@ -17,10 +18,15 @@ from .textutils import unicode_str
 
 NO_CLASSNAME = "no-testclass"
 
-FAILED = "failed"  # the test failed
-SKIPPED = "skipped"  # the test was skipped
-PASSED = "passed"  # the test completed successfully
-ABSENT = "absent"  # the test was known but not run/failed/skipped
+class TestResult(str, Enum):
+    UNTESTED = "untested"
+    PARTIAL_PASS = "partial pass"
+    PARTIAL_FAIL = "partial failure"
+    TOTAL_FAIL = "total failure"
+    FAILED = "failed"  # the test failed
+    SKIPPED = "skipped"  # the test was skipped
+    PASSED = "passed"  # the test completed successfully
+    ABSENT = "absent"  # the test was known but not run/failed/skipped
 
 
 def clean_xml_attribute(element: ET.Element, attribute: str, default: str|None=None):
@@ -153,16 +159,16 @@ class Case(AnchorBase, ToJunitXmlBase):
             return "[s]"
         return ""
 
-    def outcome(self):
+    def outcome(self) -> TestResult:
         """
         Return the result of this test case
         :return:
         """
         if self.skipped:
-            return SKIPPED
+            return TestResult.SKIPPED
         elif self.failed():
-            return FAILED
-        return PASSED
+            return TestResult.FAILED
+        return TestResult.PASSED
 
     def prefix(self):
         if self.skipped:

--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -10,23 +10,13 @@ import collections
 import os
 import uuid
 import xml.etree.ElementTree as ET
-from enum import Enum
 from typing import Any, OrderedDict
 
+from .case_result import CaseResult
 from .render import HTMLReport
 from .textutils import unicode_str
 
 NO_CLASSNAME = "no-testclass"
-
-class CaseResult(str, Enum):
-    UNTESTED = "untested"
-    PARTIAL_PASS = "partial pass"
-    PARTIAL_FAIL = "partial failure"
-    TOTAL_FAIL = "total failure"
-    FAILED = "failed"  # the test failed
-    SKIPPED = "skipped"  # the test was skipped
-    PASSED = "passed"  # the test completed successfully
-    ABSENT = "absent"  # the test was known but not run/failed/skipped
 
 
 def clean_xml_attribute(element: ET.Element, attribute: str, default: str|None=None):

--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -18,7 +18,7 @@ from .textutils import unicode_str
 
 NO_CLASSNAME = "no-testclass"
 
-class TestResult(str, Enum):
+class CaseResult(str, Enum):
     UNTESTED = "untested"
     PARTIAL_PASS = "partial pass"
     PARTIAL_FAIL = "partial failure"
@@ -159,16 +159,16 @@ class Case(AnchorBase, ToJunitXmlBase):
             return "[s]"
         return ""
 
-    def outcome(self) -> TestResult:
+    def outcome(self) -> CaseResult:
         """
         Return the result of this test case
         :return:
         """
         if self.skipped:
-            return TestResult.SKIPPED
+            return CaseResult.SKIPPED
         elif self.failed():
-            return TestResult.FAILED
-        return TestResult.PASSED
+            return CaseResult.FAILED
+        return CaseResult.PASSED
 
     def prefix(self):
         if self.skipped:

--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -58,7 +58,7 @@ class ToJunitXmlBase(object):
     """
     Base class of all objects that can be serialized to Junit XML
     """
-    def tojunit(self) -> Any:
+    def tojunit(self) -> ET.Element:
         """
         Return an Element matching this object
         :return:

--- a/junit2htmlreport/parser.py
+++ b/junit2htmlreport/parser.py
@@ -7,10 +7,13 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 import collections
-from .textutils import unicode_str
-from .render import HTMLReport
+import os
 import uuid
+import xml.etree.ElementTree as ET
+from typing import Any, OrderedDict
 
+from .render import HTMLReport
+from .textutils import unicode_str
 
 NO_CLASSNAME = "no-testclass"
 
@@ -20,7 +23,7 @@ PASSED = "passed"  # the test completed successfully
 ABSENT = "absent"  # the test was known but not run/failed/skipped
 
 
-def clean_xml_attribute(element, attribute, default=None):
+def clean_xml_attribute(element: ET.Element, attribute: str, default: str|None=None):
     """
     Get an XML attribute value and ensure it is legal in XML
     :param element:
@@ -41,7 +44,7 @@ class ParserError(Exception):
     """
     We had a problem parsing a file
     """
-    def __init__(self, message):
+    def __init__(self, message: str):
         super(ParserError, self).__init__(message)
 
 
@@ -49,14 +52,14 @@ class ToJunitXmlBase(object):
     """
     Base class of all objects that can be serialized to Junit XML
     """
-    def tojunit(self):
+    def tojunit(self) -> Any:
         """
         Return an Element matching this object
         :return:
         """
         raise NotImplementedError()
 
-    def make_element(self, xmltag, text=None, attribs=None):
+    def make_element(self, xmltag: str, text: str|None=None, attribs: dict[str, Any]|None=None):
         """
         Create an Element and put text and/or attribs into it
         :param xmltag: tag name
@@ -97,10 +100,12 @@ class Class(AnchorBase):
     """
     A namespace for a test
     """
+    name: str|None = None
+    cases: "list[Case]"
+    
     def __init__(self):
         super(Class, self).__init__()
-        self.name = None
-        self.cases = list()
+        self.cases = []
 
 
 class Property(AnchorBase, ToJunitXmlBase):
@@ -109,8 +114,8 @@ class Property(AnchorBase, ToJunitXmlBase):
     """
     def __init__(self):
         super(Property, self).__init__()
-        self.name = None
-        self.value = None
+        self.name: str|None = None
+        self.value: str|None = None
 
     def tojunit(self):
         """
@@ -127,19 +132,20 @@ class Case(AnchorBase, ToJunitXmlBase):
     """
     Test cases
     """
+    failure: str|None = None
+    failure_msg: str|None = None
+    skipped: str|None = None
+    skipped_msg: str|None = None
+    stderr: str|Any|None = None
+    stdout: str|Any|None = None
+    duration: float = 0
+    name: str|None = None
+    testclass: Class|None = None
+    properties: list[Property]
 
     def __init__(self):
         super(Case, self).__init__()
-        self.failure = None
-        self.failure_msg = None
-        self.skipped = False
-        self.skipped_msg = None
-        self.stderr = None
-        self.stdout = None
-        self.duration = 0
-        self.name = None
-        self.testclass = None
-        self.properties = list()
+        self.properties = []
 
     @property
     def display_suffix(self):
@@ -171,9 +177,14 @@ class Case(AnchorBase, ToJunitXmlBase):
         :note: this may not be the exact input we loaded
         :return:
         """
+        if self.testclass is None or self.testclass.name is None:
+            testclass_name = ""
+        else:
+            testclass_name = self.testclass.name
+
         testcase = self.make_element("testcase")
         testcase.set(u"name", unicode_str(self.name))
-        testcase.set(u"classname", unicode_str(self.testclass.name))
+        testcase.set(u"classname", unicode_str(testclass_name))
         testcase.set(u"time", unicode_str(self.duration))
 
         if self.stderr is not None:
@@ -208,13 +219,23 @@ class Case(AnchorBase, ToJunitXmlBase):
         Get the full name of a test case
         :return:
         """
-        return "{} : {}".format(self.testclass.name, self.name)
+        if self.testclass is None or self.testclass.name is None:
+            testclass_name = ""
+        else:
+            testclass_name = self.testclass.name
+        return "{} : {}".format(testclass_name, self.name)
 
     def basename(self):
         """
         Get a short name for this case
         :return:
         """
+        if (   self.name is None
+            or self.testclass is None
+            or self.testclass.name is None
+        ):
+            return None
+
         if self.name.startswith(self.testclass.name):
             return self.name[len(self.testclass.name):]
         return self.name
@@ -231,16 +252,20 @@ class Suite(AnchorBase, ToJunitXmlBase):
     """
     Contains test cases (usually only one suite per report)
     """
+    name: str|None = None
+    properties: list[Property]
+    classes: OrderedDict[str, Class]
+    duration: float = 0
+    package: str|None = None
+    errors: list[dict[str, str|Any|None]]
+    stdout: str|Any|None = None
+    stderr: str|Any|None = None
+
     def __init__(self):
         super(Suite, self).__init__()
-        self.name = None
-        self.duration = 0
         self.classes = collections.OrderedDict()
-        self.package = None
         self.properties = []
         self.errors = []
-        self.stdout = None
-        self.stderr = None
 
     def tojunit(self):
         """
@@ -260,7 +285,7 @@ class Suite(AnchorBase, ToJunitXmlBase):
             suite.append(testcase.tojunit())
         return suite
 
-    def __contains__(self, item):
+    def __contains__(self, item: str):
         """
         Return True if the given test classname is part of this test suite
         :param item:
@@ -268,7 +293,7 @@ class Suite(AnchorBase, ToJunitXmlBase):
         """
         return item in self.classes
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str):
         """
         Return the given test class object
         :param item:
@@ -276,7 +301,7 @@ class Suite(AnchorBase, ToJunitXmlBase):
         """
         return self.classes[item]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Class):
         """
         Add a test class
         :param key:
@@ -290,7 +315,7 @@ class Suite(AnchorBase, ToJunitXmlBase):
         Return all testcases
         :return:
         """
-        tests = list()
+        tests: list[Case] = []
         for testclass in self.classes:
             tests.extend(self.classes[testclass].cases)
         return tests
@@ -314,15 +339,18 @@ class Suite(AnchorBase, ToJunitXmlBase):
         Return all the passing testcases
         :return:
         """
-        return [test for test in self.all() if not test.failed() and not test.skipped()]
+        return [test for test in self.all() if not test.failed() and not test.skipped]
 
 
 class Junit(object):
     """
     Parse a single junit xml report
     """
+    filename: str
+    suites: list[Suite]
+    tree: ET.ElementTree|ET.Element
 
-    def __init__(self, filename=None, xmlstring=None):
+    def __init__(self, filename: str|None=None, xmlstring: str|None=None):
         """
         Parse the file
         :param filename:
@@ -338,23 +366,19 @@ class Junit(object):
         self.tree = None
         if self.filename is not None:
             self.tree = ET.parse(self.filename)
+
+        self.suites = []
+        if filename is not None:
+            self.filename = filename
+            self.tree = ET.parse(filename)
         elif xmlstring is not None:
-            self._read(xmlstring)
+            self.tree = ET.fromstring(xmlstring)
         else:
             raise ValueError("Missing any filename or xmlstring")
-        self.suites = []
         self.process()
 
     def __iter__(self):
         return self.suites.__iter__()
-
-    def _read(self, xmlstring):
-        """
-        Populate the junit xml document tree from a string
-        :param xmlstring:
-        :return:
-        """
-        self.tree = ET.fromstring(xmlstring)
 
     def process(self):
         """
@@ -362,7 +386,8 @@ class Junit(object):
         :return:
         """
         testrun = False
-        suites = None
+        suites: list[ET.Element]|None = None
+        root: ET.Element
         if isinstance(self.tree, ET.ElementTree):
             root = self.tree.getroot()
         else:
@@ -370,7 +395,7 @@ class Junit(object):
 
         if root.tag == "testrun":
             testrun = True
-            root = root[0]
+            root: ET.Element = root[0]
 
         if root.tag == "testsuite":
             suites = [root]
@@ -423,7 +448,7 @@ class Junit(object):
                         testclass.name = testcase.attrib["classname"]
                         cursuite[testclass.name] = testclass
 
-                    testclass = cursuite[testcase.attrib["classname"]]
+                    testclass: Class = cursuite[testcase.attrib["classname"]]
                     newcase = Case()
                     newcase.name = clean_xml_attribute(testcase, "name")
                     newcase.testclass = testclass

--- a/junit2htmlreport/render.py
+++ b/junit2htmlreport/render.py
@@ -1,19 +1,27 @@
 """
 Render junit reports as HTML
 """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .matrix import ReportMatrix
+    from .parser import Junit
+
 from jinja2 import Environment, PackageLoader, select_autoescape, FileSystemLoader
 
 
 class HTMLReport(object):
-    def __init__(self):
-        self.title = ""
-        self.report = None
+    title: str = ""
+    report: "Junit|None" = None
 
-    def load(self, report, title="JUnit2HTML Report"):
+    def load(self, report: "Junit", title: str="JUnit2HTML Report"):
         self.report = report
         self.title = title
 
     def __iter__(self):
+        if self.report is None:
+            raise Exception("A report must be loaded through `load(...)` first.")
+
         return self.report.__iter__()
 
     def __str__(self) -> str:
@@ -27,8 +35,10 @@ class HTMLReport(object):
 
 
 class HTMLMatrix(object):
-    def __init__(self, matrix, template=None):
-        self.title = "JUnit Matrix"
+    title: str = "JUnit Matrix"
+    matrix: "ReportMatrix"
+
+    def __init__(self, matrix: "ReportMatrix", template=None):
         self.matrix = matrix
         self.template = template
 

--- a/junit2htmlreport/runner.py
+++ b/junit2htmlreport/runner.py
@@ -5,7 +5,7 @@ import os
 import sys
 from argparse import ArgumentParser
 
-from junit2htmlreport import matrix, merge, parser
+from . import matrix, merge, parser
 
 PARSER = ArgumentParser(prog="junit2html")
 

--- a/junit2htmlreport/runner.py
+++ b/junit2htmlreport/runner.py
@@ -2,9 +2,10 @@
 Small command line tool to generate a html version of a junit report file
 """
 import os
-from argparse import ArgumentParser
 import sys
-from junit2htmlreport import parser, matrix, merge
+from argparse import ArgumentParser
+
+from junit2htmlreport import matrix, merge, parser
 
 PARSER = ArgumentParser(prog="junit2html")
 
@@ -38,7 +39,7 @@ PARSER.add_argument("OUTPUT", type=str, nargs="?",
                     help="Filename to save the html as")
 
 
-def run(args):
+def run(args: list[str]):
     """
     Run this tool
     :param args:

--- a/junit2htmlreport/templates/report.html
+++ b/junit2htmlreport/templates/report.html
@@ -13,7 +13,7 @@
                 <li>{{classname}}
                 <ul>
                     {% for test in suite.classes[classname].cases %}
-                    <li><a href="#{{test.anchor()}}">{{test.name}}</a>{{test.display_suffix}}</li>
+                    <li class="outcome outcome-{{test.outcome()}}"><a href="#{{test.anchor()}}">{{test.name}}</a>{{test.display_suffix}}</li>
                     {% endfor %}
                 </ul>
                 </li>

--- a/junit2htmlreport/templates/styles.css
+++ b/junit2htmlreport/templates/styles.css
@@ -82,14 +82,15 @@ h1 {
     margin-left: 0.5cm;
 }
 
-.outcome {
+.testcases .outcome {
     border-left: 1em;
     padding: 2px;
 }
 
-.outcome-failed {
+.testcases .outcome-failed {
     border-left: 1em solid lightcoral;
 }
+
 
 .outcome-passed {
     border-left: 1em solid lightgreen;
@@ -98,6 +99,11 @@ h1 {
 .outcome-skipped {
     border-left: 1em dotted silver;
 }
+
+.testcases .outcome-passed {
+    border-left: 1em solid lightgreen;
+}
+
 
 .stats-table {
 }

--- a/junit2htmlreport/templates/styles.css
+++ b/junit2htmlreport/templates/styles.css
@@ -82,6 +82,40 @@ h1 {
     margin-left: 0.5cm;
 }
 
+.toc {
+    list-style: none;
+}
+
+.toc li.outcome {
+    list-style: none;
+}
+
+.toc li.outcome::before {
+    content: "\2022";
+    color: black;
+    font-weight: bold;
+    display: inline-block;
+    width: 1.27em;
+    margin-left: -1.27em;
+    font-size: 1.2em;
+}
+
+.toc li.outcome-failed {
+    background-color: lightcoral;
+}
+
+.toc li.outcome-failed::before {
+    color: red;
+}
+
+.toc li.outcome-passed::before {
+    color: green;
+}
+
+.toc li.outcome-skipped::before {
+    color: orange;
+}
+
 .testcases .outcome {
     border-left: 1em;
     padding: 2px;
@@ -104,6 +138,9 @@ h1 {
     border-left: 1em solid lightgreen;
 }
 
+.testcases .outcome-skipped {
+    border-left: 1em solid #FED8B1;
+}
 
 .stats-table {
 }

--- a/junit2htmlreport/textutils.py
+++ b/junit2htmlreport/textutils.py
@@ -1,18 +1,16 @@
 """
 Stringify to unicode
 """
-import sys
-__py3__ = sys.version_info > (3, 0)
+
+from typing import Any
 
 
-def unicode_str(text):
+def unicode_str(text: Any|None):
     """
     Convert text to unicode
     :param text:
     :return:
     """
-    if __py3__:
-        if isinstance(text, bytes):
-            return text.decode("utf-8", "strict")
-        return str(text)
-    return unicode(text)
+    if isinstance(text, bytes):
+        return text.decode("utf-8", "strict")
+    return "" if text is None else str(text)

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -2,10 +2,11 @@
 Test the matrix functionality
 """
 import os
-from .inputfiles import get_filepath, HERE
+
 from junit2htmlreport import matrix
-from junit2htmlreport.matrix import PARTIAL_PASS, PARTIAL_FAIL, TOTAL_FAIL, UNTESTED
-from junit2htmlreport.parser import PASSED, SKIPPED, FAILED
+from junit2htmlreport.parser import CaseResult
+
+from .inputfiles import HERE, get_filepath
 
 
 def test_combined_result():
@@ -14,26 +15,26 @@ def test_combined_result():
     :return:
     """
     textmatrix = matrix.TextReportMatrix()
-    short, result = textmatrix.combined_result([PASSED, SKIPPED])
+    short, result = textmatrix.combined_result([CaseResult.PASSED, CaseResult.SKIPPED])
 
-    assert short == textmatrix.short_outcome(PASSED)
-    assert result == PASSED.title()
+    assert short == textmatrix.short_outcome(CaseResult.PASSED)
+    assert result == CaseResult.PASSED.title()
 
-    short, result = textmatrix.combined_result([PASSED, FAILED])
-    assert short == textmatrix.short_outcome(PARTIAL_FAIL)
-    assert result == PARTIAL_FAIL.title()
+    short, result = textmatrix.combined_result([CaseResult.PASSED, CaseResult.FAILED])
+    assert short == textmatrix.short_outcome(CaseResult.PARTIAL_FAIL)
+    assert result == CaseResult.PARTIAL_FAIL.title()
 
-    short, result = textmatrix.combined_result([FAILED, FAILED])
-    assert short == textmatrix.short_outcome(FAILED)
-    assert result == FAILED.title()
+    short, result = textmatrix.combined_result([CaseResult.FAILED, CaseResult.FAILED])
+    assert short == textmatrix.short_outcome(CaseResult.FAILED)
+    assert result == CaseResult.FAILED.title()
 
-    short, result = textmatrix.combined_result([PASSED])
-    assert short == textmatrix.short_outcome(PASSED)
-    assert result == PASSED.title()
+    short, result = textmatrix.combined_result([CaseResult.PASSED])
+    assert short == textmatrix.short_outcome(CaseResult.PASSED)
+    assert result == CaseResult.PASSED.title()
 
-    short, result = textmatrix.combined_result([SKIPPED, SKIPPED])
-    assert short == textmatrix.short_outcome(UNTESTED)
-    assert result == UNTESTED.title()
+    short, result = textmatrix.combined_result([CaseResult.SKIPPED, CaseResult.SKIPPED])
+    assert short == textmatrix.short_outcome(CaseResult.UNTESTED)
+    assert result == CaseResult.UNTESTED.title()
 
 
 def test_matrix_load(tmpdir):


### PR DESCRIPTION
This PR includes changes primarily to make failing tests more obvious by adding colored gutters and very visible markings for failing tests.

For example, here's what the report looks like with a failing test, and a couple "xfail" and "skip" tests:

![image](https://github.com/inorton/junit2html/assets/277061/39c27a7c-c9fd-4783-bdbf-7e3e1c311e39)

![image](https://github.com/inorton/junit2html/assets/277061/f0653a3a-c3ee-4acf-b5bd-8e101bd8438a)

---
Versus the current look:

![image](https://github.com/inorton/junit2html/assets/277061/5a7d8ee7-9a48-4b73-8757-03bba550807c)

![image](https://github.com/inorton/junit2html/assets/277061/62718eea-3178-48af-9b1b-476d79c5c169)

---
There are also changes in this PR regarding type annotations that may break backwards compatibility.